### PR TITLE
fix: deepsomatic bam compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Run DeepSomatic using flag `--model-type PACBIO`.
 
 ## DeepSomatic compatibility
 
-VACmap output is compatible with DeepSomatic without extra flags. A default read group (`ID: 1, SM: sample, PL: PACBIO`) is injected automatically when `--rg-id` is not provided. To customise, pass `--rg-id <id> --rg-sm <sample> --rg-pl PACBIO`.
+VACmap output is compatible with DeepSomatic without extra flags. A default read group (`ID: 1, SM: sample`) is injected automatically when `--rg-id` is not provided. To customise, pass `--rg-id <id> --rg-sm <sample> --rg-pl PACBIO`.
 
 
 ## Linting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,107 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What is VACmap
+
+VACmap is a long-read sequence aligner specifically designed for complex structural variation (SV) discovery. It uses non-linear chaining to detect translocations, inversions, and other complex SVs that linear aligners miss. The underlying index (`vacmap_index`) is a C extension wrapping a minimap2-like k-mer/minimizer index.
+
+## Installation
+
+Do not use provided installation instructions. Use docker image instead.
+
+```bash
+docker pull hydragenetics/vacmap:1.0.0
+```
+
+To test DeepSomatic on VACmap-produced PACBIO alignments, use docker image:
+
+```bash
+docker pull google/deepsomatic:1.9.0
+```
+
+## Running VACmap
+
+Use docker image above to run VACmap commands.
+Bind host directories by running docker with `-v /Users/andgu885/Documents/GitHub/VACmap/dir_to_bin:/dir`
+
+```bash
+# Validation with test data
+vacmap -ref testdata/reference.fasta -read testdata/read.fasta -mode S -t 4
+
+# Typical ONT/CLR run
+vacmap -ref ref.fasta -read reads.fasta -mode H -t 8 -o out.sorted.bam
+
+# HiFi/CCS run
+vacmap -ref ref.fasta -read reads.fasta -mode L -t 8 -o out.sorted.bam
+
+# Assembly-to-reference
+vacmap -ref ref.fasta -read asm.fasta -mode asm -t 8 --H --fakecigar -workdir /tmp/asm_workdir -o out.sorted.bam
+```
+
+Output is auto-sorted when the `-o` path ends in `.sorted.bam`.
+
+VACmap-aligned PACBIO (HiFi) reads are stored in `test_bam/COLO829_aligned.bam`.
+Unaligned PACBIO (HiFi) reads are stored in `test_bam/COLO829_unaligned.bam`.
+
+Run DeepSomatic using flag `--model-type PACBIO`.
+
+## DeepSomatic compatibility
+
+VACmap output is compatible with DeepSomatic without extra flags. A default read group (`ID: 1, SM: sample, PL: PACBIO`) is injected automatically when `--rg-id` is not provided. To customise, pass `--rg-id <id> --rg-sm <sample> --rg-pl PACBIO`.
+
+
+## Linting
+
+```bash
+flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+```
+
+CI runs flake8 on push/PR to `main` (`.github/workflows/python-app.yml`). There are no automated tests beyond the lint check.
+
+## Architecture
+
+### Entry point
+
+`src/vacmap/vacmap` — a Python script (no `.py` extension) installed as the `vacmap` CLI. It parses arguments via `argparse`, builds a parameter dict `pdict`, then dispatches to the appropriate mode module.
+
+### Mode dispatch
+
+Based on `-mode`, the entry point dynamically imports one of:
+
+| Mode | Module | Use case |
+|------|--------|----------|
+| `H`  | `mammap_clrnano.py` | ONT / PacBio CLR (high error rate) |
+| `L`  | `mammap_ccs.py`     | PacBio HiFi (low error rate) |
+| `S`  | `mammap_sensitive.py` | Sensitive mode for small variants (<100 bp) |
+| `R`  | `mammap_noprefercloser.py` | Fixed variation penalty; sensitive to translocations/gene conversion |
+| `asm`| `mammap_asm.py`     | Full genome / assembly alignment |
+
+Each mode module implements the core alignment logic independently (seed lookup → non-linear chaining → extension → SAM output). They share helpers from `output_functions.py`.
+
+### Key dependencies
+
+- **`vacmap_index`** (pip package `vacmap-index`): C extension providing the minimizer index (`mp.Aligner`). Wraps minimap2-style seeding.
+- **`numba`**: JIT-compiled inner loops for chaining (`@njit` decorators).
+- **`pysam`**: SAM/BAM I/O.
+- **`edlib`**: Edit-distance-based alignment extension.
+- **`mappy`**: Used only in `index.py` (standalone index builder) and `vacsim/`.
+
+### Pre-built index
+
+`index.py` is a standalone script to pre-build a `.mmi` index file:
+```bash
+python index.py ref.fasta ref.mmi
+```
+Pass the `.mmi` path as `-ref` to skip index rebuild at runtime.
+
+### vacsim
+
+`vacsim/vacsim.py` is a read simulator (separate from the aligner) used to generate synthetic test data.
+
+## Key implementation details
+
+- The non-linear chaining step is what differentiates VACmap from minimap2 — it allows anchors to form chains that represent rearranged or inverted segments.
+- `asm` mode writes intermediate files to `-workdir`; other modes are stateless (stream stdin → stdout/BAM).
+- Multiprocessing: reads are chunked and dispatched via `multiprocessing.Pool`; results are collected and written in order.
+- Output to `.sorted.bam` triggers an internal `pysam.sort` call after alignment.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Run DeepSomatic using flag `--model-type PACBIO`.
 
 ## DeepSomatic compatibility
 
-VACmap output is compatible with DeepSomatic without extra flags. A default read group (`ID: 1, SM: sample`) is injected automatically when `--rg-id` is not provided. To customise, pass `--rg-id <id> --rg-sm <sample> --rg-pl PACBIO`.
+VACmap output is compatible with DeepSomatic without extra flags. A default read group (`ID: 1, SM: sample`) is injected automatically when `--rg-id` is not provided. The `PL` field is intentionally omitted from the default — pass `--rg-pl PACBIO` (or `ONT`) to include it. Omitting `--rg-pl` will trigger a `MISSING_PLATFORM_VALUE` warning from Picard ValidateSamFile.
 
 
 ## Linting

--- a/src/vacmap/mammap_asm.py
+++ b/src/vacmap/mammap_asm.py
@@ -38,6 +38,7 @@ from io import StringIO
 import multiprocessing
 import os
 import vacmap_index as mp
+from vacmap.output_functions import nm_from_cigar
 import gzip
 import array
 import sys
@@ -328,8 +329,6 @@ def get_contig2start(contig, contig2start):
 
 import array
 
-def compute_NM_tag(query, target):
-    return edlib.align(query = query, target = target, task = 'distance')['editDistance']
 def get_bam_dict1(mapinfo, query, qual, contig2iloc, contig2seq):
     #'hhk',         ,  '1', '+', 11, 9192, 2767041, 2776138, 60
     #      0            1    2   3    4      5         6      7
@@ -352,9 +351,9 @@ def get_bam_dict1(mapinfo, query, qual, contig2iloc, contig2seq):
     for item in mapinfo:
         tmpiloc += 1
         if(item[2] == '+'):
-            nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+            nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
         else:
-            nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+            nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
         iloc2nm[tmpiloc] = nm
     if((qual != None) and (len(qual) == len(query))):
         query_qualities = fastq_q2b(qual)
@@ -4836,9 +4835,9 @@ def get_bam_dict(mapinfo, query, qual, contig2iloc, contig2seq):
     for item in mapinfo:
         tmpiloc += 1
         if(item[2] == '+'):
-            nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+            nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
         else:
-            nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+            nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
         iloc2nm[tmpiloc] = nm
     if((qual != None) and (len(qual) == len(query))):
         query_qualities = fastq_q2b(qual)
@@ -5079,9 +5078,9 @@ def get_bam_dict_stdout(mapinfo, query, qual, contig2iloc, contig2seq):
     for item in mapinfo:
         tmpiloc += 1
         if(item[2] == '+'):
-            nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+            nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
         else:
-            nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+            nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
         iloc2nm[tmpiloc] = nm
     if((qual != None) and (len(qual) == len(query))):
         query_qualities = fastq_q2b(qual)
@@ -5455,9 +5454,9 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
             item[-1], n_cigar = mergecigar_n(item[-1])
             tmpiloc += 1
             if(item[2] == '+'):
-                nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
             else:
-                nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
             iloc2nm[tmpiloc] = nm
             iloc2n_cigar[tmpiloc] = n_cigar
     else:
@@ -5470,7 +5469,7 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
                 tmp_query = rc_query[item[3]: item[4]]
                 tmp_target = get_refseq(item[1], item[5], item[6], contig2seq)
             cigarstring, mdstring, csstring, n_cigar = mergecigar_md_cs(item[-1], tmp_target, tmp_query, shortcs)
-            nm = compute_NM_tag(tmp_query, tmp_target)
+            nm = nm_from_cigar(cigarstring, tmp_query, tmp_target)
             item[-1] = cigarstring
             iloc2nm[tmpiloc] = nm
             iloc2md[tmpiloc] = mdstring
@@ -11804,9 +11803,9 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
             item[-1], n_cigar = mergecigar_n(item[-1])
             tmpiloc += 1
             if(item[2] == '+'):
-                nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
             else:
-                nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
             iloc2nm[tmpiloc] = nm
             iloc2n_cigar[tmpiloc] = n_cigar
     else:
@@ -11819,7 +11818,7 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
                 tmp_query = rc_query[item[3]: item[4]]
                 tmp_target = get_refseq(item[1], item[5], item[6], contig2seq)
             cigarstring, mdstring, csstring, n_cigar = mergecigar_md_cs(item[-1], tmp_target, tmp_query, shortcs)
-            nm = compute_NM_tag(tmp_query, tmp_target)
+            nm = nm_from_cigar(cigarstring, tmp_query, tmp_target)
             item[-1] = cigarstring
             iloc2nm[tmpiloc] = nm
             iloc2md[tmpiloc] = mdstring
@@ -15565,9 +15564,9 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
             item[-1], n_cigar = mergecigar_n(item[-1])
             tmpiloc += 1
             if(item[2] == '+'):
-                nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
             else:
-                nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
             iloc2nm[tmpiloc] = nm
             iloc2n_cigar[tmpiloc] = n_cigar
     else:
@@ -15580,7 +15579,7 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
                 tmp_query = rc_query[item[3]: item[4]]
                 tmp_target = get_refseq(item[1], item[5], item[6], contig2seq)
             cigarstring, mdstring, csstring, n_cigar = mergecigar_md_cs(item[-1], tmp_target, tmp_query, shortcs)
-            nm = compute_NM_tag(tmp_query, tmp_target)
+            nm = nm_from_cigar(cigarstring, tmp_query, tmp_target)
             item[-1] = cigarstring
             iloc2nm[tmpiloc] = nm
             iloc2md[tmpiloc] = mdstring
@@ -17277,9 +17276,9 @@ def get_bam_dict_str_comments(mapinfo, query, qual, comments, contig2iloc, conti
             item[-1], n_cigar = mergecigar_n(item[-1])
             tmpiloc += 1
             if(item[2] == '+'):
-                nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
             else:
-                nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
             iloc2nm[tmpiloc] = nm
             iloc2n_cigar[tmpiloc] = n_cigar
     else:
@@ -17292,7 +17291,7 @@ def get_bam_dict_str_comments(mapinfo, query, qual, comments, contig2iloc, conti
                 tmp_query = rc_query[item[3]: item[4]]
                 tmp_target = get_refseq(item[1], item[5], item[6], contig2seq)
             cigarstring, mdstring, csstring, n_cigar = mergecigar_md_cs(item[-1], tmp_target, tmp_query, shortcs)
-            nm = compute_NM_tag(tmp_query, tmp_target)
+            nm = nm_from_cigar(cigarstring, tmp_query, tmp_target)
             item[-1] = cigarstring
             iloc2nm[tmpiloc] = nm
             iloc2md[tmpiloc] = mdstring
@@ -19766,9 +19765,9 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
             item[-1], n_cigar = mergecigar_n(item[-1])
             tmpiloc += 1
             if(item[2] == '+'):
-                nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
             else:
-                nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
             iloc2nm[tmpiloc] = nm
             iloc2n_cigar[tmpiloc] = n_cigar
     else:
@@ -19781,7 +19780,7 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
                 tmp_query = rc_query[item[3]: item[4]]
                 tmp_target = get_refseq(item[1], item[5], item[6], contig2seq)
             cigarstring, mdstring, csstring, n_cigar = mergecigar_md_cs(item[-1], tmp_target, tmp_query, shortcs)
-            nm = compute_NM_tag(tmp_query, tmp_target)
+            nm = nm_from_cigar(cigarstring, tmp_query, tmp_target)
             item[-1] = cigarstring
             iloc2nm[tmpiloc] = nm
             iloc2md[tmpiloc] = mdstring
@@ -19910,9 +19909,9 @@ def get_bam_dict_str_comments(mapinfo, query, qual, comments, contig2iloc, conti
             item[-1], n_cigar = mergecigar_n(item[-1])
             tmpiloc += 1
             if(item[2] == '+'):
-                nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
             else:
-                nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
             iloc2nm[tmpiloc] = nm
             iloc2n_cigar[tmpiloc] = n_cigar
     else:
@@ -19925,7 +19924,7 @@ def get_bam_dict_str_comments(mapinfo, query, qual, comments, contig2iloc, conti
                 tmp_query = rc_query[item[3]: item[4]]
                 tmp_target = get_refseq(item[1], item[5], item[6], contig2seq)
             cigarstring, mdstring, csstring, n_cigar = mergecigar_md_cs(item[-1], tmp_target, tmp_query, shortcs)
-            nm = compute_NM_tag(tmp_query, tmp_target)
+            nm = nm_from_cigar(cigarstring, tmp_query, tmp_target)
             item[-1] = cigarstring
             iloc2nm[tmpiloc] = nm
             iloc2md[tmpiloc] = mdstring

--- a/src/vacmap/mammap_ccs.py
+++ b/src/vacmap/mammap_ccs.py
@@ -38,6 +38,7 @@ from io import StringIO
 import multiprocessing
 import os
 import vacmap_index as mp
+from vacmap.output_functions import nm_from_cigar
 import gzip
 import array
 import sys
@@ -326,8 +327,6 @@ def get_contig2start(contig, contig2start):
 
 import array
 
-def compute_NM_tag(query, target):
-    return edlib.align(query = query, target = target, task = 'distance')['editDistance']
 def get_bam_dict1(mapinfo, query, qual, contig2iloc, contig2seq):
     #'hhk',         ,  '1', '+', 11, 9192, 2767041, 2776138, 60
     #      0            1    2   3    4      5         6      7
@@ -350,9 +349,9 @@ def get_bam_dict1(mapinfo, query, qual, contig2iloc, contig2seq):
     for item in mapinfo:
         tmpiloc += 1
         if(item[2] == '+'):
-            nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+            nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
         else:
-            nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+            nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
         iloc2nm[tmpiloc] = nm
     if((qual != None) and (len(qual) == len(query))):
         query_qualities = fastq_q2b(qual)
@@ -4834,9 +4833,9 @@ def get_bam_dict(mapinfo, query, qual, contig2iloc, contig2seq):
     for item in mapinfo:
         tmpiloc += 1
         if(item[2] == '+'):
-            nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+            nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
         else:
-            nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+            nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
         iloc2nm[tmpiloc] = nm
     if((qual != None) and (len(qual) == len(query))):
         query_qualities = fastq_q2b(qual)
@@ -5077,9 +5076,9 @@ def get_bam_dict_stdout(mapinfo, query, qual, contig2iloc, contig2seq):
     for item in mapinfo:
         tmpiloc += 1
         if(item[2] == '+'):
-            nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+            nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
         else:
-            nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+            nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
         iloc2nm[tmpiloc] = nm
     if((qual != None) and (len(qual) == len(query))):
         query_qualities = fastq_q2b(qual)
@@ -16901,9 +16900,9 @@ def get_bam_dict_str_comments(mapinfo, query, qual, comments, contig2iloc, conti
             item[-1], n_cigar = mergecigar_n(item[-1])
             tmpiloc += 1
             if(item[2] == '+'):
-                nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
             else:
-                nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
             iloc2nm[tmpiloc] = nm
             iloc2n_cigar[tmpiloc] = n_cigar
     else:
@@ -16916,7 +16915,7 @@ def get_bam_dict_str_comments(mapinfo, query, qual, comments, contig2iloc, conti
                 tmp_query = rc_query[item[3]: item[4]]
                 tmp_target = get_refseq(item[1], item[5], item[6], contig2seq)
             cigarstring, mdstring, csstring, n_cigar = mergecigar_md_cs(item[-1], tmp_target, tmp_query, shortcs)
-            nm = compute_NM_tag(tmp_query, tmp_target)
+            nm = nm_from_cigar(cigarstring, tmp_query, tmp_target)
             item[-1] = cigarstring
             iloc2nm[tmpiloc] = nm
             iloc2md[tmpiloc] = mdstring
@@ -20872,9 +20871,9 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
             item[-1], n_cigar = mergecigar_n(item[-1])
             tmpiloc += 1
             if(item[2] == '+'):
-                nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
             else:
-                nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
             iloc2nm[tmpiloc] = nm
             iloc2n_cigar[tmpiloc] = n_cigar
             if(fakecigar == True):
@@ -20904,7 +20903,7 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
                 tmp_query = rc_query[item[3]: item[4]]
                 tmp_target = get_refseq(item[1], item[5], item[6], contig2seq)
             cigarstring, mdstring, csstring, n_cigar = mergecigar_md_cs(item[-1], tmp_target, tmp_query, shortcs)
-            nm = compute_NM_tag(tmp_query, tmp_target)
+            nm = nm_from_cigar(cigarstring, tmp_query, tmp_target)
             item[-1] = cigarstring
             iloc2nm[tmpiloc] = nm
             iloc2md[tmpiloc] = mdstring
@@ -21054,9 +21053,9 @@ def get_bam_dict_str_comments(mapinfo, query, qual, comments, contig2iloc, conti
             item[-1], n_cigar = mergecigar_n(item[-1])
             tmpiloc += 1
             if(item[2] == '+'):
-                nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
             else:
-                nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
             iloc2nm[tmpiloc] = nm
             iloc2n_cigar[tmpiloc] = n_cigar
             if(fakecigar == True):
@@ -21086,7 +21085,7 @@ def get_bam_dict_str_comments(mapinfo, query, qual, comments, contig2iloc, conti
                 tmp_query = rc_query[item[3]: item[4]]
                 tmp_target = get_refseq(item[1], item[5], item[6], contig2seq)
             cigarstring, mdstring, csstring, n_cigar = mergecigar_md_cs(item[-1], tmp_target, tmp_query, shortcs)
-            nm = compute_NM_tag(tmp_query, tmp_target)
+            nm = nm_from_cigar(cigarstring, tmp_query, tmp_target)
             item[-1] = cigarstring
             iloc2nm[tmpiloc] = nm
             iloc2md[tmpiloc] = mdstring

--- a/src/vacmap/mammap_clrnano.py
+++ b/src/vacmap/mammap_clrnano.py
@@ -38,6 +38,7 @@ from io import StringIO
 import multiprocessing
 import os
 import vacmap_index as mp
+from vacmap.output_functions import nm_from_cigar
 import gzip
 import array
 import sys
@@ -326,8 +327,6 @@ def get_contig2start(contig, contig2start):
 
 import array
 
-def compute_NM_tag(query, target):
-    return edlib.align(query = query, target = target, task = 'distance')['editDistance']
 def get_bam_dict1(mapinfo, query, qual, contig2iloc, contig2seq):
     #'hhk',         ,  '1', '+', 11, 9192, 2767041, 2776138, 60
     #      0            1    2   3    4      5         6      7
@@ -350,9 +349,9 @@ def get_bam_dict1(mapinfo, query, qual, contig2iloc, contig2seq):
     for item in mapinfo:
         tmpiloc += 1
         if(item[2] == '+'):
-            nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+            nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
         else:
-            nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+            nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
         iloc2nm[tmpiloc] = nm
     if((qual != None) and (len(qual) == len(query))):
         query_qualities = fastq_q2b(qual)
@@ -4834,9 +4833,9 @@ def get_bam_dict(mapinfo, query, qual, contig2iloc, contig2seq):
     for item in mapinfo:
         tmpiloc += 1
         if(item[2] == '+'):
-            nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+            nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
         else:
-            nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+            nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
         iloc2nm[tmpiloc] = nm
     if((qual != None) and (len(qual) == len(query))):
         query_qualities = fastq_q2b(qual)
@@ -5077,9 +5076,9 @@ def get_bam_dict_stdout(mapinfo, query, qual, contig2iloc, contig2seq):
     for item in mapinfo:
         tmpiloc += 1
         if(item[2] == '+'):
-            nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+            nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
         else:
-            nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+            nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
         iloc2nm[tmpiloc] = nm
     if((qual != None) and (len(qual) == len(query))):
         query_qualities = fastq_q2b(qual)
@@ -16900,9 +16899,9 @@ def get_bam_dict_str_comments(mapinfo, query, qual, comments, contig2iloc, conti
             item[-1], n_cigar = mergecigar_n(item[-1])
             tmpiloc += 1
             if(item[2] == '+'):
-                nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
             else:
-                nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
             iloc2nm[tmpiloc] = nm
             iloc2n_cigar[tmpiloc] = n_cigar
     else:
@@ -16915,7 +16914,7 @@ def get_bam_dict_str_comments(mapinfo, query, qual, comments, contig2iloc, conti
                 tmp_query = rc_query[item[3]: item[4]]
                 tmp_target = get_refseq(item[1], item[5], item[6], contig2seq)
             cigarstring, mdstring, csstring, n_cigar = mergecigar_md_cs(item[-1], tmp_target, tmp_query, shortcs)
-            nm = compute_NM_tag(tmp_query, tmp_target)
+            nm = nm_from_cigar(cigarstring, tmp_query, tmp_target)
             item[-1] = cigarstring
             iloc2nm[tmpiloc] = nm
             iloc2md[tmpiloc] = mdstring
@@ -20873,9 +20872,9 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
             item[-1], n_cigar = mergecigar_n(item[-1])
             tmpiloc += 1
             if(item[2] == '+'):
-                nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
             else:
-                nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
             iloc2nm[tmpiloc] = nm
             iloc2n_cigar[tmpiloc] = n_cigar
             if(fakecigar == True):
@@ -20905,7 +20904,7 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
                 tmp_query = rc_query[item[3]: item[4]]
                 tmp_target = get_refseq(item[1], item[5], item[6], contig2seq)
             cigarstring, mdstring, csstring, n_cigar = mergecigar_md_cs(item[-1], tmp_target, tmp_query, shortcs)
-            nm = compute_NM_tag(tmp_query, tmp_target)
+            nm = nm_from_cigar(cigarstring, tmp_query, tmp_target)
             item[-1] = cigarstring
             iloc2nm[tmpiloc] = nm
             iloc2md[tmpiloc] = mdstring
@@ -21054,9 +21053,9 @@ def get_bam_dict_str_comments(mapinfo, query, qual, comments, contig2iloc, conti
             item[-1], n_cigar = mergecigar_n(item[-1])
             tmpiloc += 1
             if(item[2] == '+'):
-                nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
             else:
-                nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
             iloc2nm[tmpiloc] = nm
             iloc2n_cigar[tmpiloc] = n_cigar
             if(fakecigar == True):
@@ -21086,7 +21085,7 @@ def get_bam_dict_str_comments(mapinfo, query, qual, comments, contig2iloc, conti
                 tmp_query = rc_query[item[3]: item[4]]
                 tmp_target = get_refseq(item[1], item[5], item[6], contig2seq)
             cigarstring, mdstring, csstring, n_cigar = mergecigar_md_cs(item[-1], tmp_target, tmp_query, shortcs)
-            nm = compute_NM_tag(tmp_query, tmp_target)
+            nm = nm_from_cigar(cigarstring, tmp_query, tmp_target)
             item[-1] = cigarstring
             iloc2nm[tmpiloc] = nm
             iloc2md[tmpiloc] = mdstring

--- a/src/vacmap/mammap_noprefercloser.py
+++ b/src/vacmap/mammap_noprefercloser.py
@@ -38,6 +38,7 @@ from io import StringIO
 import multiprocessing
 import os
 import vacmap_index as mp
+from vacmap.output_functions import nm_from_cigar
 import gzip
 import array
 import sys
@@ -326,8 +327,6 @@ def get_contig2start(contig, contig2start):
 
 import array
 
-def compute_NM_tag(query, target):
-    return edlib.align(query = query, target = target, task = 'distance')['editDistance']
 def get_bam_dict1(mapinfo, query, qual, contig2iloc, contig2seq):
     #'hhk',         ,  '1', '+', 11, 9192, 2767041, 2776138, 60
     #      0            1    2   3    4      5         6      7
@@ -350,9 +349,9 @@ def get_bam_dict1(mapinfo, query, qual, contig2iloc, contig2seq):
     for item in mapinfo:
         tmpiloc += 1
         if(item[2] == '+'):
-            nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+            nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
         else:
-            nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+            nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
         iloc2nm[tmpiloc] = nm
     if((qual != None) and (len(qual) == len(query))):
         query_qualities = fastq_q2b(qual)
@@ -4834,9 +4833,9 @@ def get_bam_dict(mapinfo, query, qual, contig2iloc, contig2seq):
     for item in mapinfo:
         tmpiloc += 1
         if(item[2] == '+'):
-            nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+            nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
         else:
-            nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+            nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
         iloc2nm[tmpiloc] = nm
     if((qual != None) and (len(qual) == len(query))):
         query_qualities = fastq_q2b(qual)
@@ -5077,9 +5076,9 @@ def get_bam_dict_stdout(mapinfo, query, qual, contig2iloc, contig2seq):
     for item in mapinfo:
         tmpiloc += 1
         if(item[2] == '+'):
-            nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+            nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
         else:
-            nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+            nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
         iloc2nm[tmpiloc] = nm
     if((qual != None) and (len(qual) == len(query))):
         query_qualities = fastq_q2b(qual)
@@ -5453,9 +5452,9 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
             item[-1], n_cigar = mergecigar_n(item[-1])
             tmpiloc += 1
             if(item[2] == '+'):
-                nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
             else:
-                nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
             iloc2nm[tmpiloc] = nm
             iloc2n_cigar[tmpiloc] = n_cigar
     else:
@@ -5468,7 +5467,7 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
                 tmp_query = rc_query[item[3]: item[4]]
                 tmp_target = get_refseq(item[1], item[5], item[6], contig2seq)
             cigarstring, mdstring, csstring, n_cigar = mergecigar_md_cs(item[-1], tmp_target, tmp_query, shortcs)
-            nm = compute_NM_tag(tmp_query, tmp_target)
+            nm = nm_from_cigar(cigarstring, tmp_query, tmp_target)
             item[-1] = cigarstring
             iloc2nm[tmpiloc] = nm
             iloc2md[tmpiloc] = mdstring
@@ -11802,9 +11801,9 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
             item[-1], n_cigar = mergecigar_n(item[-1])
             tmpiloc += 1
             if(item[2] == '+'):
-                nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
             else:
-                nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
             iloc2nm[tmpiloc] = nm
             iloc2n_cigar[tmpiloc] = n_cigar
     else:
@@ -11817,7 +11816,7 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
                 tmp_query = rc_query[item[3]: item[4]]
                 tmp_target = get_refseq(item[1], item[5], item[6], contig2seq)
             cigarstring, mdstring, csstring, n_cigar = mergecigar_md_cs(item[-1], tmp_target, tmp_query, shortcs)
-            nm = compute_NM_tag(tmp_query, tmp_target)
+            nm = nm_from_cigar(cigarstring, tmp_query, tmp_target)
             item[-1] = cigarstring
             iloc2nm[tmpiloc] = nm
             iloc2md[tmpiloc] = mdstring
@@ -15563,9 +15562,9 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
             item[-1], n_cigar = mergecigar_n(item[-1])
             tmpiloc += 1
             if(item[2] == '+'):
-                nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
             else:
-                nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
             iloc2nm[tmpiloc] = nm
             iloc2n_cigar[tmpiloc] = n_cigar
     else:
@@ -15578,7 +15577,7 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
                 tmp_query = rc_query[item[3]: item[4]]
                 tmp_target = get_refseq(item[1], item[5], item[6], contig2seq)
             cigarstring, mdstring, csstring, n_cigar = mergecigar_md_cs(item[-1], tmp_target, tmp_query, shortcs)
-            nm = compute_NM_tag(tmp_query, tmp_target)
+            nm = nm_from_cigar(cigarstring, tmp_query, tmp_target)
             item[-1] = cigarstring
             iloc2nm[tmpiloc] = nm
             iloc2md[tmpiloc] = mdstring
@@ -17273,9 +17272,9 @@ def get_bam_dict_str_comments(mapinfo, query, qual, comments, contig2iloc, conti
             item[-1], n_cigar = mergecigar_n(item[-1])
             tmpiloc += 1
             if(item[2] == '+'):
-                nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
             else:
-                nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
             iloc2nm[tmpiloc] = nm
             iloc2n_cigar[tmpiloc] = n_cigar
     else:
@@ -17288,7 +17287,7 @@ def get_bam_dict_str_comments(mapinfo, query, qual, comments, contig2iloc, conti
                 tmp_query = rc_query[item[3]: item[4]]
                 tmp_target = get_refseq(item[1], item[5], item[6], contig2seq)
             cigarstring, mdstring, csstring, n_cigar = mergecigar_md_cs(item[-1], tmp_target, tmp_query, shortcs)
-            nm = compute_NM_tag(tmp_query, tmp_target)
+            nm = nm_from_cigar(cigarstring, tmp_query, tmp_target)
             item[-1] = cigarstring
             iloc2nm[tmpiloc] = nm
             iloc2md[tmpiloc] = mdstring
@@ -19762,9 +19761,9 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
             item[-1], n_cigar = mergecigar_n(item[-1])
             tmpiloc += 1
             if(item[2] == '+'):
-                nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
             else:
-                nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
             iloc2nm[tmpiloc] = nm
             iloc2n_cigar[tmpiloc] = n_cigar
     else:
@@ -19777,7 +19776,7 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
                 tmp_query = rc_query[item[3]: item[4]]
                 tmp_target = get_refseq(item[1], item[5], item[6], contig2seq)
             cigarstring, mdstring, csstring, n_cigar = mergecigar_md_cs(item[-1], tmp_target, tmp_query, shortcs)
-            nm = compute_NM_tag(tmp_query, tmp_target)
+            nm = nm_from_cigar(cigarstring, tmp_query, tmp_target)
             item[-1] = cigarstring
             iloc2nm[tmpiloc] = nm
             iloc2md[tmpiloc] = mdstring
@@ -19906,9 +19905,9 @@ def get_bam_dict_str_comments(mapinfo, query, qual, comments, contig2iloc, conti
             item[-1], n_cigar = mergecigar_n(item[-1])
             tmpiloc += 1
             if(item[2] == '+'):
-                nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
             else:
-                nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
             iloc2nm[tmpiloc] = nm
             iloc2n_cigar[tmpiloc] = n_cigar
     else:
@@ -19921,7 +19920,7 @@ def get_bam_dict_str_comments(mapinfo, query, qual, comments, contig2iloc, conti
                 tmp_query = rc_query[item[3]: item[4]]
                 tmp_target = get_refseq(item[1], item[5], item[6], contig2seq)
             cigarstring, mdstring, csstring, n_cigar = mergecigar_md_cs(item[-1], tmp_target, tmp_query, shortcs)
-            nm = compute_NM_tag(tmp_query, tmp_target)
+            nm = nm_from_cigar(cigarstring, tmp_query, tmp_target)
             item[-1] = cigarstring
             iloc2nm[tmpiloc] = nm
             iloc2md[tmpiloc] = mdstring
@@ -21531,9 +21530,9 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
             item[-1], n_cigar = mergecigar_n(item[-1])
             tmpiloc += 1
             if(item[2] == '+'):
-                nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
             else:
-                nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
             iloc2nm[tmpiloc] = nm
             iloc2n_cigar[tmpiloc] = n_cigar
             if(fakecigar == True):
@@ -21563,7 +21562,7 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
                 tmp_query = rc_query[item[3]: item[4]]
                 tmp_target = get_refseq(item[1], item[5], item[6], contig2seq)
             cigarstring, mdstring, csstring, n_cigar = mergecigar_md_cs(item[-1], tmp_target, tmp_query, shortcs)
-            nm = compute_NM_tag(tmp_query, tmp_target)
+            nm = nm_from_cigar(cigarstring, tmp_query, tmp_target)
             item[-1] = cigarstring
             iloc2nm[tmpiloc] = nm
             iloc2md[tmpiloc] = mdstring
@@ -21720,9 +21719,9 @@ def get_bam_dict_str_comments(mapinfo, query, qual, comments, contig2iloc, conti
             item[-1], n_cigar = mergecigar_n(item[-1])
             tmpiloc += 1
             if(item[2] == '+'):
-                nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
             else:
-                nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
             iloc2nm[tmpiloc] = nm
             iloc2n_cigar[tmpiloc] = n_cigar
             if(fakecigar == True):
@@ -21752,7 +21751,7 @@ def get_bam_dict_str_comments(mapinfo, query, qual, comments, contig2iloc, conti
                 tmp_query = rc_query[item[3]: item[4]]
                 tmp_target = get_refseq(item[1], item[5], item[6], contig2seq)
             cigarstring, mdstring, csstring, n_cigar = mergecigar_md_cs(item[-1], tmp_target, tmp_query, shortcs)
-            nm = compute_NM_tag(tmp_query, tmp_target)
+            nm = nm_from_cigar(cigarstring, tmp_query, tmp_target)
             item[-1] = cigarstring
             iloc2nm[tmpiloc] = nm
             iloc2md[tmpiloc] = mdstring
@@ -21925,9 +21924,9 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
             item[-1], n_cigar = mergecigar_n(item[-1])
             tmpiloc += 1
             if(item[2] == '+'):
-                nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
             else:
-                nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
             iloc2nm[tmpiloc] = nm
             iloc2n_cigar[tmpiloc] = n_cigar
             if(fakecigar == True):
@@ -21957,7 +21956,7 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
                 tmp_query = rc_query[item[3]: item[4]]
                 tmp_target = get_refseq(item[1], item[5], item[6], contig2seq)
             cigarstring, mdstring, csstring, n_cigar = mergecigar_md_cs(item[-1], tmp_target, tmp_query, shortcs)
-            nm = compute_NM_tag(tmp_query, tmp_target)
+            nm = nm_from_cigar(cigarstring, tmp_query, tmp_target)
             item[-1] = cigarstring
             iloc2nm[tmpiloc] = nm
             iloc2md[tmpiloc] = mdstring
@@ -22108,9 +22107,9 @@ def get_bam_dict_str_comments(mapinfo, query, qual, comments, contig2iloc, conti
             item[-1], n_cigar = mergecigar_n(item[-1])
             tmpiloc += 1
             if(item[2] == '+'):
-                nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
             else:
-                nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
             iloc2nm[tmpiloc] = nm
             iloc2n_cigar[tmpiloc] = n_cigar
             if(fakecigar == True):
@@ -22140,7 +22139,7 @@ def get_bam_dict_str_comments(mapinfo, query, qual, comments, contig2iloc, conti
                 tmp_query = rc_query[item[3]: item[4]]
                 tmp_target = get_refseq(item[1], item[5], item[6], contig2seq)
             cigarstring, mdstring, csstring, n_cigar = mergecigar_md_cs(item[-1], tmp_target, tmp_query, shortcs)
-            nm = compute_NM_tag(tmp_query, tmp_target)
+            nm = nm_from_cigar(cigarstring, tmp_query, tmp_target)
             item[-1] = cigarstring
             iloc2nm[tmpiloc] = nm
             iloc2md[tmpiloc] = mdstring

--- a/src/vacmap/mammap_sensitive.py
+++ b/src/vacmap/mammap_sensitive.py
@@ -38,6 +38,7 @@ from io import StringIO
 import multiprocessing
 import os
 import vacmap_index as mp
+from vacmap.output_functions import nm_from_cigar
 import gzip
 import array
 import sys
@@ -326,8 +327,6 @@ def get_contig2start(contig, contig2start):
 
 import array
 
-def compute_NM_tag(query, target):
-    return edlib.align(query = query, target = target, task = 'distance')['editDistance']
 
 @njit
 def get_optimal_chain_sortbyreadpos_forSV_inv_test_merged_fine_numpy(one_mapinfo, kmersize = 15, skipcost = 50., maxdiff = 30, maxgap = 500):
@@ -20479,9 +20478,9 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
             item[-1], n_cigar = mergecigar_n(item[-1])
             tmpiloc += 1
             if(item[2] == '+'):
-                nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
             else:
-                nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
             iloc2nm[tmpiloc] = nm
             iloc2n_cigar[tmpiloc] = n_cigar
             if(fakecigar == True):
@@ -20511,7 +20510,7 @@ def get_bam_dict_str(mapinfo, query, qual, contig2iloc, contig2seq, md, shortcs,
                 tmp_query = rc_query[item[3]: item[4]]
                 tmp_target = get_refseq(item[1], item[5], item[6], contig2seq)
             cigarstring, mdstring, csstring, n_cigar = mergecigar_md_cs(item[-1], tmp_target, tmp_query, shortcs)
-            nm = compute_NM_tag(tmp_query, tmp_target)
+            nm = nm_from_cigar(cigarstring, tmp_query, tmp_target)
             item[-1] = cigarstring
             iloc2nm[tmpiloc] = nm
             iloc2md[tmpiloc] = mdstring
@@ -20660,9 +20659,9 @@ def get_bam_dict_str_comments(mapinfo, query, qual, comments, contig2iloc, conti
             item[-1], n_cigar = mergecigar_n(item[-1])
             tmpiloc += 1
             if(item[2] == '+'):
-                nm = compute_NM_tag(query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], query, get_refseq(item[1], item[5], item[6], contig2seq))
             else:
-                nm = compute_NM_tag(rc_query[item[3]: item[4]], get_refseq(item[1], item[5], item[6], contig2seq))
+                nm = nm_from_cigar(item[8], rc_query, get_refseq(item[1], item[5], item[6], contig2seq))
             iloc2nm[tmpiloc] = nm
             iloc2n_cigar[tmpiloc] = n_cigar
             if(fakecigar == True):
@@ -20692,7 +20691,7 @@ def get_bam_dict_str_comments(mapinfo, query, qual, comments, contig2iloc, conti
                 tmp_query = rc_query[item[3]: item[4]]
                 tmp_target = get_refseq(item[1], item[5], item[6], contig2seq)
             cigarstring, mdstring, csstring, n_cigar = mergecigar_md_cs(item[-1], tmp_target, tmp_query, shortcs)
-            nm = compute_NM_tag(tmp_query, tmp_target)
+            nm = nm_from_cigar(cigarstring, tmp_query, tmp_target)
             item[-1] = cigarstring
             iloc2nm[tmpiloc] = nm
             iloc2md[tmpiloc] = mdstring

--- a/src/vacmap/output_functions.py
+++ b/src/vacmap/output_functions.py
@@ -294,6 +294,8 @@ def sam_bam_writer_asm(cooked_queue, header, out_path="-"):
 
 import re as _re
 
+_CIGAR_RE = _re.compile(r'(\d+)([MIDNSHP=X])')
+
 
 def nm_from_cigar(cigar_string, query_seq, ref_seq):
     """
@@ -316,7 +318,7 @@ def nm_from_cigar(cigar_string, query_seq, ref_seq):
     nm = 0
     q_pos = 0
     r_pos = 0
-    for m in _re.finditer(r'(\d+)([MIDNSHP=X])', cigar_string):
+    for m in _CIGAR_RE.finditer(cigar_string):
         length = int(m.group(1))
         op = m.group(2)
         if op == 'M':

--- a/src/vacmap/output_functions.py
+++ b/src/vacmap/output_functions.py
@@ -291,3 +291,57 @@ def sam_bam_writer_asm(cooked_queue, header, out_path="-"):
                 process.kill()
     else:
         raise ValueError("Output path must end with .sam, .bam, sorted.bam or be '-' for stdout.")
+
+import re as _re
+
+
+def nm_from_cigar(cigar_string, query_seq, ref_seq):
+    """
+    Compute the NM tag consistent with the CIGAR string.
+
+    NM = mismatches (M ops) + inserted bases (I ops) + deleted bases (D ops).
+    This matches the definition validated by Picard/GATK.
+
+    Args:
+        cigar_string: CIGAR string, e.g. '3S50M2I10M1D5M4S'
+        query_seq:    Query (read) sequence. For alignments that include soft
+                      clips in the CIGAR, pass the FULL read so that S ops
+                      advance the position pointer correctly. For inner
+                      sub-alignments with no S ops, pass the aligned slice.
+        ref_seq:      Reference sequence covering the aligned region only.
+
+    Returns:
+        int: NM value >= 0
+    """
+    nm = 0
+    q_pos = 0
+    r_pos = 0
+    for m in _re.finditer(r'(\d+)([MIDNSHP=X])', cigar_string):
+        length = int(m.group(1))
+        op = m.group(2)
+        if op == 'M':
+            for i in range(length):
+                if query_seq[q_pos + i].upper() != ref_seq[r_pos + i].upper():
+                    nm += 1
+            q_pos += length
+            r_pos += length
+        elif op == 'I':
+            nm += length
+            q_pos += length
+        elif op == 'D':
+            nm += length
+            r_pos += length
+        elif op == 'N':
+            r_pos += length
+        elif op == 'S':
+            q_pos += length
+        elif op in ('H', 'P'):
+            pass
+        elif op == '=':
+            q_pos += length
+            r_pos += length
+        elif op == 'X':
+            nm += length
+            q_pos += length
+            r_pos += length
+    return nm

--- a/src/vacmap/vacmap
+++ b/src/vacmap/vacmap
@@ -212,8 +212,12 @@ def main():
             pdict['shortcs'] = True
 
     rg_metadata = collect_rg_metadata(args, pdict)
+    # Ensure a read group is always present (required by DeepSomatic and GATK-based tools)
+    if not rg_metadata:
+        rg_metadata = {"ID": "1", "SM": "sample", "PL": "PACBIO"}
+        pdict['rg-id'] = "1"
 
-    
+
 
     # Logic: Validate Output Path
     if pdict['o'] != "-":

--- a/src/vacmap/vacmap
+++ b/src/vacmap/vacmap
@@ -447,9 +447,15 @@ def main():
                     name = rec.query_name
                     if hash(name) in unique_set: continue
                     seq = rec.query_sequence.upper()
+                    raw_qual = rec.query_qualities  # array.array('B') of ints, or None
                     if rec.is_reverse:
                         seq = str(Seq(seq).reverse_complement())
-                    qual = None 
+                        if raw_qual is not None:
+                            raw_qual = raw_qual[::-1]  # reverse to match reversed sequence
+                    if raw_qual is not None and not pdict['Q']:
+                        qual = bytes(q + 33 for q in raw_qual).decode('ascii')
+                    else:
+                        qual = None
                 else:
                     # mp.fastx_read returns tuple
                     name = rec[0]

--- a/src/vacmap/vacmap
+++ b/src/vacmap/vacmap
@@ -214,7 +214,7 @@ def main():
     rg_metadata = collect_rg_metadata(args, pdict)
     # Ensure a read group is always present (required by DeepSomatic and GATK-based tools)
     if not rg_metadata:
-        rg_metadata = {"ID": "1", "SM": "sample", "PL": "PACBIO"}
+        rg_metadata = {"ID": "1", "SM": "sample"}
         pdict['rg-id'] = "1"
 
 

--- a/src/vacmap/vacmap
+++ b/src/vacmap/vacmap
@@ -446,7 +446,11 @@ def main():
                 if is_bam:
                     name = rec.query_name
                     if hash(name) in unique_set: continue
-                    seq = rec.query_sequence.upper()
+                    seq = rec.query_sequence
+                    if seq is None:
+                        logging.warning(f"Skipping read {name}: no sequence in BAM record")
+                        continue
+                    seq = seq.upper()
                     raw_qual = rec.query_qualities  # array.array('B') of ints, or None
                     if rec.is_reverse:
                         seq = str(Seq(seq).reverse_complement())

--- a/src/vacmap/vacmap
+++ b/src/vacmap/vacmap
@@ -504,6 +504,9 @@ def main():
                 tmp_st = c_time
                 tmp_count = count
 
+        if is_bam:
+            bamfile.close()
+
     # --- Cleanup ---
     # Signal workers to stop
     for _ in range(max_worker):

--- a/src/vacmap/vacmap
+++ b/src/vacmap/vacmap
@@ -216,6 +216,11 @@ def main():
     if not rg_metadata:
         rg_metadata = {"ID": "1", "SM": "sample"}
         pdict['rg-id'] = "1"
+        logging.warning(
+            "No --rg-pl specified; PL field omitted from the default read group. "
+            "Picard ValidateSamFile will report MISSING_PLATFORM_VALUE. "
+            "Pass --rg-pl PACBIO (or ONT) to suppress this."
+        )
 
 
 

--- a/tests/test_nm_from_cigar.py
+++ b/tests/test_nm_from_cigar.py
@@ -1,0 +1,61 @@
+"""Tests for nm_from_cigar in output_functions."""
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from vacmap.output_functions import nm_from_cigar
+
+
+def test_perfect_match():
+    assert nm_from_cigar('5M', 'ACGTA', 'ACGTA') == 0
+
+
+def test_single_mismatch():
+    # position 2: G vs T
+    assert nm_from_cigar('5M', 'ACGTA', 'ACTTA') == 1
+
+
+def test_insertion():
+    # 3M 2I 3M: 2 inserted bases → NM=2
+    # query: ACG + TT (inserted) + GTA  = ACGTTGTA (8 bases)
+    # ref:   ACG + GTA = ACGGTA (6 bases)
+    assert nm_from_cigar('3M2I3M', 'ACGTTGTA', 'ACGGTA') == 2
+
+
+def test_deletion():
+    # 3M 1D 3M: 1 deleted base → NM=1
+    # query: ACG + GTA = ACGGTA (6 bases)
+    # ref:   ACG + X (deleted) + GTA = ACGXGTA (7 bases)
+    assert nm_from_cigar('3M1D3M', 'ACGGTA', 'ACGXGTA') == 1
+
+
+def test_soft_clip_not_counted():
+    # 3S 5M 2S: soft clips do not contribute to NM
+    # query: AAA (soft) + GGGCC (aligned) + TT (soft) = AAAGGGCCTT
+    # ref for aligned region: GGGCC
+    assert nm_from_cigar('3S5M2S', 'AAAGGGCCTT', 'GGGCC') == 0
+
+
+def test_soft_clip_with_mismatch():
+    # 3S 5M 2S: 1 mismatch in aligned region (position 3 of aligned: X vs C)
+    # query aligned portion: GGGXC (pos 3,4,5,6,7 of full read)
+    assert nm_from_cigar('3S5M2S', 'AAAGGGXCTT', 'GGGCC') == 1
+
+
+def test_hard_clip_ignored():
+    # 2H 5M 2H: hard clips — no sequence stored, q_pos unchanged
+    assert nm_from_cigar('2H5M2H', 'ACGTA', 'ACGTA') == 0
+
+
+def test_case_insensitive():
+    assert nm_from_cigar('5M', 'acgta', 'ACGTA') == 0
+
+
+def test_mixed_ops():
+    # 3M 1I 2M 1D 3M
+    # query: ACG (3M) + T (1I) + AG (2M) + GTA (3M) = ACGTAGGTA  (9 query bases)
+    # ref:   ACG (3M) + TG (2M) + X (1D) + GTA (3M) = ACGTGXGTA  (9 ref bases)
+    # mismatches: 2M: A vs T = 1 mismatch; I: +1; D: +1 → NM=3
+    query = 'ACGTAGGTA'
+    ref   = 'ACGTGXGTA'
+    assert nm_from_cigar('3M1I2M1D3M', query, ref) == 3


### PR DESCRIPTION
## Fix DeepSomatic BAM compatibility, issue #16 

VACmap-aligned BAM files failed `picard ValidateSamFile` with three classes of errors, all of which caused DeepSomatic to crash. This PR fixes all three.                                                                                                      

### Bug 1 — QUALITY_NOT_STORED (BAM input quality scores discarded)                                                                                  

When the input was a BAM file, `rec.query_qualities` was never read — quality scores were hardcoded to `None`. The fix reads the `pysam array.array('B')` of integer Phred scores, re-encodes them to Phred+33 ASCII (matching the FASTQ path), and reverses them when the sequence is reverse-complemented. Added a guard for reads with no sequence (`query_sequence` is `None`) and ensured the BAM file handle is closed after reading.

### Bug 2 — MISSING_READ_GROUP / RECORD_MISSING_READ_GROUP

The @RG header and per-alignment RG:Z tag were only written when `--rg-id` was explicitly passed on the command line. The fix injects a minimal default read group (ID: 1, SM: sample) whenever the user does not supply `--rg-id`, so DeepSomatic and other GATK-based tools always find a valid read group.

#### PL tag

- No `--rg-pl`: default RG injected without PL; a WARNING is printed to stderr telling the user to pass `--rg-pl PACBIO` or `--rg-pl ONT`. DeepSomatic still works; Picard reports MISSING_PLATFORM_VALUE. 
- `--rg-pl PACBIO` (or ONT): full @RG written, both DeepSomatic and Picard are clean.

### Bug 3 — INVALID_TAG_NM (NM tag inconsistent with CIGAR)

All five mode modules computed the NM tag via `edlib.align(...)[editDistance]`, which returns the optimal global edit distance independent of the CIGAR string. Because VACmap sometimes emits a sub-optimal (non-edit-distance-minimising) CIGAR (e.g., to preserve breakpoint representation), the edlib NM was systematically lower than what the CIGAR encodes — Picard and DeepSomatic both validate NM by walking the CIGAR, so any mismatch is a hard error.                                                                                                                              

The fix adds `nm_from_cigar(cigar_string, query_seq, ref_seq)` to `output_functions.py`. It walks the CIGAR and counts mismatches on M ops (by comparing bases), plus lengths of I and D ops — exactly the definition in the SAM spec. The module-level pre-compiled regex avoids recompilation on each call. `compute_NM_tag` (the edlib wrapper) has been removed from all five mode modules and replaced with `nm_from_cigar`. 

## Tests                                                                                                                                            

Added `tests/test_nm_from_cigar.py` with 9 unit tests covering: perfect match, single mismatch, insertion, deletion, soft clip not counted, soft clip with mismatch, hard clip ignored, case insensitivity, and mixed CIGAR ops.

## Validation                                                

After this fix, `picard ValidateSamFile` reports no errors and no quality/read-group warnings on the COLO829 HiFi test BAM. DeepSomatic completes without the "no quality scores" crash or `Check failed: offset + len segfault`.

## flake8 errors
These are pre-existing F821 errors and out of scope for this PR.
